### PR TITLE
Add parallel test, add race detector

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ tmp
 internal/app/net_sender/net_sender
 internal/app/remote_http_file_test/remote_http_file_test
 internal/app/volatile_file_test/volatile_file_test
+.idea
+*.iml

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GOTEST=$(GOCMD) test
 MAKE=make
 
 test:
-	@$(GOTEST) -v ./...
+	@$(GOTEST) -race -v ./...
 
 build:
 	@cd cmd/flowd; $(GOBUILD) -o ../../builds/$(BINARY_NAME) -v


### PR DESCRIPTION
Starting on #9 
NB: this adds a failing test, and makes more tests fail by enabling race detector.