### PR TITLE
Olegs/pipeline refactoring

### DIFF
--- a/internal/app/speed_tester/main.go
+++ b/internal/app/speed_tester/main.go
@@ -38,10 +38,10 @@ func main() {
 	cntr = 0
 
 	go reportCnt()
-	if err := repl.SetUp(); err != nil {
+	if err := repl.(*replicator.Replicator).SetUp(); err != nil {
 		panic(err.Error())
 	}
-	if err := tcprcv.SetUp(); err != nil {
+	if err := tcprcv.(*tcp_rcv.TCP).SetUp(); err != nil {
 		panic(err.Error())
 	}
 

--- a/pkg/config/registry.go
+++ b/pkg/config/registry.go
@@ -97,7 +97,7 @@ func traverseProviders() ([]Provider, error) {
 	top := data.NewTopology(provList...)
 	for name, prov := range registry.providers {
 		for _, dep := range prov.DependsOn() {
-			top.Connect(dep, name)
+			top.Connect(registry.providers[name], registry.providers[dep])
 		}
 	}
 	resolved, err := top.Sort()

--- a/pkg/pipeline/pipeline.go
+++ b/pkg/pipeline/pipeline.go
@@ -41,10 +41,10 @@ type Pipeline struct {
 	compTree *data.NTree
 }
 
-type ConstrFunc func(string, core.Params, *core.Context) (core.Link, error)
+type Constructor func(string, core.Params, *core.Context) (core.Link, error)
 
 var (
-	CompBuilders = map[string]ConstrFunc{
+	CompBuilders = map[string]Constructor{
 		"receiver.tcp":  tcp_rcv.New,
 		"receiver.udp":  udp_rcv.New,
 		"receiver.http": http_rcv.New,

--- a/pkg/pipeline/pipeline_test.go
+++ b/pkg/pipeline/pipeline_test.go
@@ -9,7 +9,7 @@ import (
 	yaml "gopkg.in/yaml.v2"
 )
 
-func TestPipeline_buildComp(t *testing.T) {
+func TestPipeline_buildComponents(t *testing.T) {
 	tests := []struct {
 		name string
 		cfg  *config.CfgBlockComponent
@@ -94,7 +94,7 @@ func TestPipeline_buildComp(t *testing.T) {
 	}
 	for _, testCase := range tests {
 		t.Run(testCase.name, func(t *testing.T) {
-			comp, err := buildComp(testCase.cfg.Module, *testCase.cfg, core.NewContext())
+			comp, err := buildComponent(testCase.cfg.Module, *testCase.cfg, core.NewContext())
 			if err != nil {
 				t.Errorf("Failed to build component %s: %s", testCase.cfg.Module, err)
 			} else {

--- a/pkg/util/data/topology.go
+++ b/pkg/util/data/topology.go
@@ -23,6 +23,10 @@ func NewTopology(nodes ...TopologyNode) *Topology {
 	}
 }
 
+func (top *Topology) AddNode(node TopologyNode) {
+	top.Nodes = append(top.Nodes, node)
+}
+
 func (top *Topology) Connect(from, to TopologyNode) {
 	top.Edges = append(top.Edges, TopologyEdge{From: from, To: to})
 }


### PR DESCRIPTION
Pipeline node traversal ops are replaced with topologically sorted list instead of n-trees.